### PR TITLE
ECPRESOURCEPUPPET-15 Add a configuration to Puppet

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ repositories {
 	}
 }
 
+group = "com.electriccloud"
+description = "Plugins : EC-Puppet"
+version = "1.0.4"
+
 apply plugin: 'flow-gradle-plugin'
 apply plugin: 'license'
 
@@ -34,13 +38,11 @@ license {
     exclude "**/project.xml"
 }
 
-group = "com.electriccloud"
-description = "Plugins : EC-Puppet"
-version = "1.0.3"
-
 
 task wrapper(type: Wrapper) {
 	gradleVersion = '2.3'
 }
 
-tasks.jar.dependsOn = [processProjectXml]
+gwt {
+        modules 'ecplugins.puppet.ConfigurationManagement'
+}

--- a/cgi-bin/puppet.cgi
+++ b/cgi-bin/puppet.cgi
@@ -1,0 +1,230 @@
+#!/bin/sh
+
+exec "$COMMANDER_HOME/bin/ec-perl" -x "$0" "${@}"
+ 
+################################
+#!perl
+# puppet.cgi -
+#
+# Get/set EC-Puppet configuration info for UI
+#
+# Copyright (c) 2015 Electric Cloud, Inc.
+# All rights reserved
+################################
+
+use strict;
+use warnings;
+use Getopt::Long;
+use File::Spec;
+use File::Temp;
+use ElectricCommander;
+use ElectricCommander::PropMod;
+use ElectricCommander::PropDB;
+use CGI qw(:standard);
+
+use constant {
+    SUCCESS => 0,
+    ERROR   => 1,
+};
+
+# used for output redirection
+$::tmpOut = "";
+$::tmpErr = "";
+$::oldout;
+$::olderr;
+
+################################
+# main - Main program for the application.
+#
+# Arguments:
+#   -
+#
+# Returns:
+#   0 - Success
+#   1 - Error
+#
+################################
+sub main() {
+
+    # globals
+    $::cg = CGI->new();
+    print $::cg->header(
+            -type => 'text/html',
+            -status => 200,
+            -Cache_control => 'no-cache, no-store, must-revalidate');
+
+    $::opts = $::cg->Vars;
+    $::ec = new ElectricCommander();
+    $::ec->abortOnError(0);
+
+    # make sure no libraries print to STDOUT
+    saveOutErr();
+
+    # Check for required arguments.
+    if (!defined $::opts->{cmd} || "$::opts->{cmd}" eq "") {
+        retError("error: cmd is required parameter");
+    }
+
+    # ---------------------------------------------------------------
+    # Dispatch operation
+    # ---------------------------------------------------------------
+    for ($::opts->{cmd})
+    {
+        # modes
+        /getCfgList/i and do   { getCfgList(); last; };
+    }
+    retError("unknown command $::opts->{cmd}");
+
+    exit SUCCESS;
+}
+
+################################
+# getCfgList - Return the list of configurations from puppet
+#
+# Arguments:
+#   -
+#
+# Returns:
+#   0 - Success
+#   1 - Error
+#
+################################
+sub getCfgList {
+
+    my $gcfg = new ElectricCommander::PropDB($::ec,"/projects/@PLUGIN_NAME@/puppet_cfgs");
+
+    my %cfgs = $gcfg->getRows();
+    # print results as XML block
+    my $xml = "";
+    $xml .= "<cfgs>
+";
+    foreach my $cfg (keys  %cfgs) {
+        $xml .= "  <cfg>
+";
+        $xml .= "     <name>$cfg</name>
+";
+        # Insert your additional configuration list fields (NOTE: you'll need to modify PuppetConfigList.java also)
+        $xml .= "  </cfg>
+";
+    }
+    $xml .= "</cfgs>
+";
+    
+    printXML($xml);
+    exit SUCCESS;
+}
+
+################################
+# retError - Return an error message
+#
+# Arguments:
+#   msg - Message to return
+#
+# Returns:
+#   0 - Success
+#   1 - Error
+#
+################################
+sub retError {
+    my ($msg) = @_;
+
+    printXML("<error>$msg</error>
+");
+    exit ERROR;
+}
+
+################################
+# printXML - Print the XML block, add stdout, stderr
+#
+# Arguments:
+#   xml - xml string to print
+#
+# Returns:
+#   -
+#
+################################
+sub printXML {
+    my ($xml) = @_;
+
+    my ($out, $err) = retrieveOutErr();
+
+    print "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+";
+    print "<response>
+";
+    print "$xml
+";
+    print "<stdout>" . xmlQuote($out) . "</stdout>
+";
+    print "<stderr>" . xmlQuote($err) . "</stderr>
+";
+    print "</response>";
+}
+
+################################
+# saveOutErr - Redirect stdout/stderr to files so that any spurious output from commands does not end up on the return to the cgi caller
+#
+# Arguments:
+#   -
+#
+# Returns:
+#   -
+#
+################################
+sub saveOutErr {
+    # temporarily save STDOUT/STDERR to files
+    open $::oldout, ">&STDOUT"  or die "Can't dup STDOUT: $!";
+    open $::olderr, ">&STDERR"  or die "Can't dup STDERR: $!";
+    close STDOUT;
+    open STDOUT, '>', \$::tmpOut or die "Can't open STDOUT: $!";
+    close STDERR;
+    open STDERR, '>', \$::tmpErr or die "Can't open STDOUT: $!";
+
+}
+
+################################
+# retrieveOutErr - Reset stdout/sterr back to normal and return the contents of the temp files
+#
+# Arguments:
+#   -
+#
+# Returns:
+#   tmpOut - Content of out file
+#   tmpErr - Content of error file
+#
+################################
+sub retrieveOutErr {
+    # reconnect to normal STDOUT/STDERR
+    open STDOUT, ">&", $::oldout or die "can't reinstate $!";
+    open STDERR, ">&", $::olderr or die "can't reinstate $!";
+    return ($::tmpOut, $::tmpErr);
+}
+
+################################
+# xmlQuote - Quote special characters such as & to generate well-formed XML character data.
+#
+# Arguments:
+#   string - String whose contents should be quoted.
+#
+# Returns:
+#   string - Quoted string
+#
+################################
+sub xmlQuote {
+    my ($string) = @_;
+
+    $string =~ s/&/&amp;/g;
+    $string =~ s/</&lt;/g;
+    $string =~ s/>/&gt;/g;
+    $string =~ s{([\0-\x{08}\x{0b}\x{0c}\x{0e}-\x{1f}])}{
+    sprintf("%%%02x", ord($1))}ge;
+    return $string;
+}
+
+main();
+
+
+
+
+
+

--- a/cgi-bin/puppetMonitor.cgi
+++ b/cgi-bin/puppetMonitor.cgi
@@ -1,0 +1,208 @@
+#!/bin/sh
+
+exec "$COMMANDER_HOME/bin/ec-perl" -x "$0" "${@}"
+ 
+#!perl
+
+################################
+# monitorJob.cgi
+#
+# Monitors a job: waits for it to complete and reports on its success or
+# failure.
+#
+# Copyright (c) 2015 Electric Cloud, Inc.
+# All rights reserved
+################################
+
+use warnings;
+use strict;
+use ElectricCommander;
+use XML::XPath;
+use CGI;
+
+use constant {
+    SUCCESS => 0,
+    ERROR   => 1,
+};
+
+
+my $gTimeout = 20;
+
+################################
+# main - Main program for the application.
+#
+# Arguments:
+#   -
+#
+# Returns:
+#   -
+#
+################################
+sub main {
+
+    # Get CGI args
+    my $cgi = new CGI;
+    my $cgiArgs = $cgi->Vars;
+    
+    # Check for required args
+    my $jobId = $cgiArgs->{jobId};
+    if (!defined $jobId || "$jobId" eq "") {
+        reportError($cgi, "jobId is a required parameter");
+    }
+    
+    # Wait for job
+    my $ec = new ElectricCommander({abortOnError => 0});
+    my $xpath = $ec->waitForJob($jobId, $gTimeout);
+    my $errors = $ec->checkAllErrors($xpath);
+    
+    if ("$errors" ne "") {
+        reportError($cgi, $errors);
+    }
+    
+    my $status = $xpath->findvalue("//status");
+    if ("$status" ne "completed") {
+        
+        # Abort job and report failure
+        abortJobAndReportError($cgi, $ec, $jobId);
+    }
+    
+    my $outcome = $xpath->findvalue("//outcome");
+    if ("$outcome" ne "success") {
+        
+        # Report job errors
+        reportJobErrors($cgi, $ec, $jobId);
+    }
+    
+    # If the job was successful and the debug flag is not set, delete it
+    my $debug = $cgiArgs->{debug};
+    if (!defined $debug || "$debug" ne "1") {
+        $ec->deleteJob($jobId);
+    }
+    
+    # Report the job's success
+    reportSuccess($cgi);
+}
+
+################################
+# abortJobAndReportError - Abort the job and report the timeout error.
+#
+# Arguments:
+#   cgi   
+#   ec    - ElectricCommander instance
+#   jobId - int identifier for the job 
+#
+# Returns:
+#   -
+#
+################################
+sub abortJobAndReportError {
+    my ($cgi, $ec, $jobId) = @_;
+    
+    my $errMsg = "Aborting job after reaching timeout";
+        
+    # Try to abort the job
+    my $xpath = $ec->abortJob($jobId);
+    my $errors = $ec->checkAllErrors($xpath);
+    if ("$errors" ne "") {
+        reportError($cgi, $errMsg . "
+" . $errors);
+    }
+    
+    # Wait for the job to finish aborting
+    $xpath = $ec->waitForJob($jobId, $gTimeout);
+    $errors = $ec->checkAllErrors($xpath);
+    if ("$errors" ne "") {
+        reportError($cgi, $errMsg . "
+" . $errors);
+    }
+    
+    # Check to see if the job actually aborted
+    my $status = $xpath->findvalue("//status");
+    if ("$status" ne "completed") {
+        reportError($cgi, $errMsg . "
+Job still running after abort");
+    }
+    
+    reportError($cgi, $errMsg . "
+Job successfully aborted");
+}
+
+################################
+# reportJobErrors - Look for errors in the job to report.
+#
+# Arguments:
+#   cgi   
+#   ec    - ElectricCommander instance
+#   jobId - int identifier for the job 
+#
+# Returns:
+#   -
+#
+################################
+sub reportJobErrors {
+    my ($cgi, $ec, $jobId) = @_;
+    
+    # Get job details
+    my $xpath = $ec->getJobDetails($jobId);
+    my $errors = $ec->checkAllErrors($xpath);
+    if ("$errors" ne "") {
+        reportError($cgi, $errors);
+    }
+    
+    # Look for configError first
+    my $configError = $xpath->findvalue("//job/propertySheet/property[propertyName='configError']/value");
+    if (defined $configError && "$configError" ne "") {
+        reportError($cgi, $configError)
+    }
+    
+    # Find the first error message and report it
+    my @errorMessages = $xpath->findnodes("//errorMessage");
+    if (@errorMessages > 0) {
+        my $firstMessage = $errorMessages[0]->string_value();
+        reportError($cgi, $firstMessage);
+    }
+    
+    # Report a generic error message if we couldn't find a specific one on the
+    # job
+    reportError($cgi, "Configuration creation failed");
+}
+
+################################
+# reportError - Print the error message and exit.
+#
+# Arguments:
+#   cgi   
+#   error - string to print
+#
+# Returns:
+#   0 - Success
+#   1 - Error
+#
+################################
+sub reportError {
+    my ($cgi, $error) = @_;
+    
+    print $cgi->header("text/html");
+    print $error;
+    exit ERROR;
+}
+
+################################
+# reportSuccess - Report success.
+#
+# Arguments:
+#   cgi   
+#
+# Returns:
+#   -
+#
+################################
+sub reportSuccess {
+    my ($cgi) = @_;
+    
+    print $cgi->header("text/html");
+    print "Success";
+}
+
+main();
+exit SUCCESS;

--- a/pages/EC-Puppet_help.xml
+++ b/pages/EC-Puppet_help.xml
@@ -230,6 +230,12 @@
 
         <h1>Release Notes</h1>
 
+        <h2>@PLUGIN_KEY@-1.0.4</h2>
+
+        <ul>
+            <li>Added configuration to plugin.</li>
+        </ul>
+
         <h2>@PLUGIN_KEY@-1.0.3</h2>
 
         <ul>

--- a/pages/configurations.xml
+++ b/pages/configurations.xml
@@ -1,0 +1,11 @@
+<page>
+    <componentContainer>
+        <title>Puppet Configurations</title>
+        <helpLink>/pages/@PLUGIN_NAME@/help</helpLink>
+        <component plugin="@PLUGIN_KEY@"
+                   version="@PLUGIN_VERSION@" 
+                   ref="ConfigurationManagement">
+            <panel>list</panel>
+        </component>
+    </componentContainer>
+</page>

--- a/pages/editConfiguration.xml
+++ b/pages/editConfiguration.xml
@@ -1,0 +1,11 @@
+<page>
+    <componentContainer>
+        <title>Edit Puppet Configuration</title>
+        <helpLink>/pages/@PLUGIN_NAME@/help</helpLink>
+        <component plugin="@PLUGIN_KEY@"
+                   version="@PLUGIN_VERSION@" 
+                   ref="ConfigurationManagement">
+            <panel>edit</panel>
+        </component>
+    </componentContainer>
+</page>

--- a/pages/newConfiguration.xml
+++ b/pages/newConfiguration.xml
@@ -1,0 +1,11 @@
+<page>
+    <componentContainer>
+        <title>New Puppet Configuration</title>
+        <helpLink>/pages/@PLUGIN_NAME@/help</helpLink>
+        <component plugin="@PLUGIN_KEY@"
+                   version="@PLUGIN_VERSION@"
+                   ref="ConfigurationManagement">
+            <panel>create</panel>
+        </component>
+    </componentContainer>
+</page>

--- a/src/main/java/ecplugins/puppet/client/ConfigurationList.java
+++ b/src/main/java/ecplugins/puppet/client/ConfigurationList.java
@@ -1,0 +1,254 @@
+/**
+ *  Copyright 2015 Electric Cloud, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// ConfigurationList.java --
+//
+// ConfigurationList.java is part of ElectricFlow.
+//
+// Copyright (c) 2015 Electric Cloud, Inc.
+// All rights reserved.
+//
+
+package ecplugins.puppet.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gwt.http.client.Request;
+import com.google.gwt.http.client.RequestCallback;
+import com.google.gwt.http.client.RequestException;
+import com.google.gwt.http.client.Response;
+import com.google.gwt.user.client.Window.Location;
+import com.google.gwt.user.client.ui.Anchor;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+
+import ecinternal.client.DialogClickHandler;
+import ecinternal.client.ListBase;
+
+
+import com.electriccloud.commander.client.ChainedCallback;
+import com.electriccloud.commander.gwt.client.requests.CgiRequestProxy;
+import com.electriccloud.commander.client.requests.RunProcedureRequest;
+import com.electriccloud.commander.client.responses.DefaultRunProcedureResponseCallback;
+import com.electriccloud.commander.client.responses.RunProcedureResponse;
+import com.electriccloud.commander.gwt.client.ui.ListTable;
+import com.electriccloud.commander.gwt.client.ui.SimpleErrorBox;
+
+import com.electriccloud.commander.gwt.client.util.CommanderUrlBuilder;
+
+import static ecinternal.client.InternalComponentBaseFactory.getPluginName;
+
+
+
+import static com.electriccloud.commander.gwt.client.util.CommanderUrlBuilder.createPageUrl;
+import static com.electriccloud.commander.gwt.client.util.CommanderUrlBuilder.createRedirectUrl;
+
+/**
+ * EC-Puppet Configuration List.
+ */
+public class ConfigurationList
+    extends ListBase
+{
+
+    //~ Instance fields --------------------------------------------------------
+
+    private PuppetConfigList m_configList;
+
+    //~ Constructors -----------------------------------------------------------
+
+    public ConfigurationList()
+    {
+        super("ecgc", "Puppet Configurations", "All Configurations");
+        m_configList = new PuppetConfigList();
+    }
+
+    //~ Methods ----------------------------------------------------------------
+
+    @Override protected Anchor constructCreateLink()
+    {
+        CommanderUrlBuilder urlBuilder = createPageUrl(getPluginName(),
+                "newConfiguration");
+
+        urlBuilder.setParameter("redirectTo",
+            createRedirectUrl().buildString());
+
+        return new Anchor("Create Configuration", urlBuilder.buildString());
+    }
+
+    @Override protected void load()
+    {
+        setStatus("Loading...");
+
+        PuppetConfigListLoader loader = new PuppetConfigListLoader(m_configList, this,
+                new ChainedCallback() {
+                    @Override public void onComplete()
+                    {
+                        loadList();
+                    }
+                });
+
+        loader.load();
+    }
+
+    private void deleteConfiguration(String configName)
+    {
+        setStatus("Deleting...");
+        clearErrorMessages();
+
+        // Build runProcedure request
+        RunProcedureRequest request = getRequestFactory()
+                .createRunProcedureRequest();
+
+        request.setProjectName("/plugins/" + getPluginName() + "/project");
+        request.setProcedureName("DeleteConfiguration");
+        request.addActualParameter("config", configName);
+        request.setCallback(new DefaultRunProcedureResponseCallback(this) {
+                @Override public void handleResponse(
+                        RunProcedureResponse response)
+                {
+
+                    if (getLog().isDebugEnabled()) {
+                        getLog().debug(
+                            "Commander runProcedure request returned jobId: "
+                                + response.getJobId());
+                    }
+
+                    waitForJob(response.getJobId().toString());
+                }
+            });
+
+        if (getLog().isDebugEnabled()) {
+            getLog().debug("Issuing Commander request: " + request);
+        }
+
+        doRequest(request);
+    }
+
+    private void loadList()
+    {
+        ListTable listTable = getListTable();
+
+        if (!m_configList.isEmpty()) {
+            listTable.addHeaderRow(true, "Configuration Name");
+        }
+
+        for (String configName : m_configList.getConfigNames()) {
+
+            // Config name
+            Label configNameLabel = new Label(configName);
+
+            // "Edit" link
+            CommanderUrlBuilder urlBuilder = createPageUrl(getPluginName(),
+                    "editConfiguration");
+
+            urlBuilder.setParameter("configName", configName);
+            urlBuilder.setParameter("redirectTo",
+                createRedirectUrl().buildString());
+
+            Anchor editConfigLink = new Anchor("Edit",
+                    urlBuilder.buildString());
+
+            // "Delete" link
+            Anchor             deleteConfigLink = new Anchor("Delete");
+            DialogClickHandler dch              = new DialogClickHandler(
+                    new DeleteConfirmationDialog(configName,
+                        "Are you sure you want to delete the Puppet configuration '"
+                            + configName + "'?") {
+                        @Override protected void doDelete()
+                        {
+                            deleteConfiguration(m_objectId);
+                        }
+                    });
+
+            deleteConfigLink.addClickHandler(dch);
+
+            // Add the row
+            editConfigLink.getElement()
+                          .setId(getIdPrefix() + "-edit");
+            deleteConfigLink.getElement()
+                            .setId(getIdPrefix() + "-delete");
+
+            Widget actions = this.getUIFactory().constructActionList(editConfigLink,
+                    deleteConfigLink);
+
+            listTable.addRow(configNameLabel, actions);
+        }
+
+        clearStatus();
+    }
+
+    private void waitForJob(final String jobId)
+    {
+        CgiRequestProxy     cgiRequestProxy = new CgiRequestProxy(
+                getPluginName(), "puppetMonitor.cgi");
+        Map<String, String> cgiParams       = new HashMap<String, String>();
+
+        cgiParams.put("jobId", jobId);
+
+        // Pass debug flag to CGI, which will use it to determine whether to
+        // clean up a successful job
+        if ("1".equals(getGetParameter("debug"))) {
+            cgiParams.put("debug", "1");
+        }
+
+        try {
+            cgiRequestProxy.issueGetRequest(cgiParams, new RequestCallback() {
+                    @Override public void onError(
+                            Request   request,
+                            Throwable exception)
+                    {
+                        addErrorMessage("CGI request failed:: ", exception);
+                    }
+
+                    @Override public void onResponseReceived(
+                            Request  request,
+                            Response response)
+                    {
+                        String responseString = response.getText();
+
+                        if (getLog().isDebugEnabled()) {
+                            getLog().debug(
+                                "CGI response received: " + responseString);
+                        }
+
+                        if (responseString.startsWith("Success")) {
+
+                            // We're done!
+                            Location.reload();
+                        }
+                        else {
+                            SimpleErrorBox      error      = getUIFactory()
+                                    .createSimpleErrorBox(
+                                        "Error occurred during configuration deletion: "
+                                        + responseString);
+                            CommanderUrlBuilder urlBuilder = CommanderUrlBuilder
+                                    .createUrl("jobDetails.php")
+                                    .setParameter("jobId", jobId);
+
+                            error.add(
+                                new Anchor("(See job for details)",
+                                    urlBuilder.buildString()));
+                            addErrorMessage(error);
+                        }
+                    }
+                });
+        }
+        catch (RequestException e) {
+            addErrorMessage("CGI request failed:: ", e);
+        }
+    }
+}

--- a/src/main/java/ecplugins/puppet/client/ConfigurationManagementFactory.java
+++ b/src/main/java/ecplugins/puppet/client/ConfigurationManagementFactory.java
@@ -1,0 +1,76 @@
+/**
+ *  Copyright 2015 Electric Cloud, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// ConfigurationManagementFactory.java --
+//
+// ConfigurationManagementFactory.java is part of ElectricFlow.
+//
+// Copyright (c) 2015 Electric Cloud, Inc.
+// All rights reserved.
+//
+
+package ecplugins.puppet.client;
+
+import ecinternal.client.InternalComponentBaseFactory;
+import ecinternal.client.InternalFormBase;
+import ecinternal.client.PropertySheetEditor;
+
+import com.electriccloud.commander.gwt.client.BrowserContext;
+import com.electriccloud.commander.gwt.client.Component;
+import com.electriccloud.commander.gwt.client.ComponentContext;
+import org.jetbrains.annotations.NotNull;
+
+import static com.electriccloud.commander.gwt.client.util.CommanderUrlBuilder.createPageUrl;
+
+public class ConfigurationManagementFactory
+    extends InternalComponentBaseFactory
+{
+
+    //~ Methods ----------------------------------------------------------------
+
+    @NotNull
+    @Override public Component createComponent(ComponentContext jso)
+    {
+        String    panel     = jso.getParameter("panel");
+        Component component;
+
+        if ("create".equals(panel)) {
+            component = new CreateConfiguration();
+        }
+        else if ("edit".equals(panel)) {
+            String configName    = BrowserContext.getInstance()
+                                                 .getGetParameter("configName");
+            String propSheetPath = "/plugins/" + getPluginName()
+                    + "/project/puppet_cfgs/" + configName;
+            String formXmlPath   = "/plugins/" + getPluginName()
+                    + "/project/ui_forms/EditConfigForm";
+
+            component = new PropertySheetEditor("ecgc",
+                    "Edit Puppet Configuration", configName,
+                    propSheetPath, formXmlPath, getPluginName());
+
+            ((InternalFormBase) component).setDefaultRedirectToUrl(
+                createPageUrl(getPluginName(), "configurations").buildString());
+        }
+        else {
+
+            // Default panel is "list"
+            component = new ConfigurationList();
+        }
+
+        return component;
+    }
+}

--- a/src/main/java/ecplugins/puppet/client/CreateConfiguration.java
+++ b/src/main/java/ecplugins/puppet/client/CreateConfiguration.java
@@ -1,0 +1,215 @@
+/**
+ *  Copyright 2015 Electric Cloud, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// CreateConfiguration.java --
+//
+// CreateConfiguration.java is part of ElectricFlow.
+//
+// Copyright (c) 2015 Electric Cloud, Inc.
+// All rights reserved.
+//
+
+package ecplugins.puppet.client;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gwt.http.client.Request;
+import com.google.gwt.http.client.RequestCallback;
+import com.google.gwt.http.client.RequestException;
+import com.google.gwt.http.client.Response;
+import com.google.gwt.user.client.ui.Anchor;
+
+import ecinternal.client.InternalFormBase;
+
+import ecinternal.client.ui.CustomEditorLoader;
+
+import com.electriccloud.commander.gwt.client.requests.CgiRequestProxy;
+import com.electriccloud.commander.client.requests.RunProcedureRequest;
+import com.electriccloud.commander.client.responses.DefaultRunProcedureResponseCallback;
+import com.electriccloud.commander.client.responses.RunProcedureResponse;
+import com.electriccloud.commander.gwt.client.ui.CredentialEditor;
+import com.electriccloud.commander.gwt.client.ui.FormBuilder;
+import com.electriccloud.commander.gwt.client.ui.FormTable;
+import com.electriccloud.commander.gwt.client.ui.SimpleErrorBox;
+import com.electriccloud.commander.gwt.client.util.CommanderUrlBuilder;
+
+import static ecinternal.client.InternalComponentBaseFactory.getPluginName;
+
+import static com.electriccloud.commander.gwt.client.util.CommanderUrlBuilder.createPageUrl;
+import static com.electriccloud.commander.gwt.client.util.CommanderUrlBuilder.createUrl;
+
+/**
+ * Create Puppet Configuration.
+ */
+public class CreateConfiguration
+    extends InternalFormBase
+{
+
+    //~ Constructors -----------------------------------------------------------
+
+    public CreateConfiguration()
+    {
+        super("New Puppet Configuration", "Puppet Configurations");
+
+        CommanderUrlBuilder urlBuilder = createPageUrl(getPluginName(),
+                "configurations");
+
+        setDefaultRedirectToUrl(urlBuilder.buildString());
+    }
+
+    //~ Methods ----------------------------------------------------------------
+
+    @Override protected FormTable initializeFormTable()
+    {
+        return getUIFactory().createFormBuilder();
+    }
+
+    @Override protected void load()
+    {
+        FormBuilder fb = (FormBuilder) getFormTable();
+
+        setStatus("Loading...");
+
+        CustomEditorLoader loader = new CustomEditorLoader(fb, this);
+
+        loader.setCustomEditorPath("/plugins/" + getPluginName()
+                + "/project/ui_forms/CreateConfigForm");
+        loader.load();
+        clearStatus();
+    }
+
+    @Override protected void submit()
+    {
+        setStatus("Saving...");
+        clearAllErrors();
+
+        FormBuilder fb = (FormBuilder) getFormTable();
+
+        if (!fb.validate()) {
+            clearStatus();
+
+            return;
+        }
+
+        // Build runProcedure request
+        RunProcedureRequest request = getRequestFactory()
+                .createRunProcedureRequest();
+
+        request.setProjectName("/plugins/" + getPluginName() + "/project");
+        request.setProcedureName("CreateConfiguration");
+
+        Map<String, String> params           = fb.getValues();
+        Collection<String>  credentialParams = fb.getCredentialIds();
+
+        for (String paramName : params.keySet()) {
+
+            if (credentialParams.contains(paramName)) {
+                CredentialEditor credential = fb.getCredential(paramName);
+
+                request.addCredentialParameter(paramName,
+                    credential.getUsername(), credential.getPassword());
+            }
+            else {
+                request.addActualParameter(paramName, params.get(paramName));
+            }
+        }
+
+        // Launch the procedure
+        request.setCallback(new DefaultRunProcedureResponseCallback(this) {
+                @Override public void handleResponse(
+                        RunProcedureResponse response)
+                {
+
+                    if (getLog().isDebugEnabled()) {
+                        getLog().debug(
+                            "Commander runProcedure request returned jobId: "
+                                + response.getJobId());
+                    }
+
+                    waitForJob(response.getJobId().toString());
+                }
+            });
+
+        if (getLog().isDebugEnabled()) {
+            getLog().debug("Issuing Commander request: " + request);
+        }
+
+        doRequest(request);
+    }
+
+    private void waitForJob(final String jobId)
+    {
+        CgiRequestProxy     cgiRequestProxy = new CgiRequestProxy(
+                getPluginName(), "puppetMonitor.cgi");
+        Map<String, String> cgiParams       = new HashMap<String, String>();
+
+        cgiParams.put("jobId", jobId);
+
+        // Pass debug flag to CGI, which will use it to determine whether to
+        // clean up a successful job
+        if ("1".equals(getGetParameter("debug"))) {
+            cgiParams.put("debug", "1");
+        }
+
+        try {
+            cgiRequestProxy.issueGetRequest(cgiParams, new RequestCallback() {
+                    @Override public void onError(
+                            Request   request,
+                            Throwable exception)
+                    {
+                        addErrorMessage("CGI request failed: ", exception);
+                    }
+
+                    @Override public void onResponseReceived(
+                            Request  request,
+                            Response response)
+                    {
+                        String responseString = response.getText();
+
+                        if (getLog().isDebugEnabled()) {
+                            getLog().debug(
+                                "CGI response received: " + responseString);
+                        }
+
+                        if (responseString.startsWith("Success")) {
+
+                            // We're done!
+                            cancel();
+                        }
+                        else {
+                            SimpleErrorBox      error      = getUIFactory()
+                                    .createSimpleErrorBox(
+                                        "Error occurred during configuration creation: "
+                                        + responseString);
+                            CommanderUrlBuilder urlBuilder = createUrl(
+                                    "jobDetails.php").setParameter("jobId",
+                                    jobId);
+
+                            error.add(
+                                new Anchor("(See job for details)",
+                                    urlBuilder.buildString()));
+                            addErrorMessage(error);
+                        }
+                    }
+                });
+        }
+        catch (RequestException e) {
+            addErrorMessage("CGI request failed: ", e);
+        }
+    }
+}

--- a/src/main/java/ecplugins/puppet/client/PuppetConfigList.java
+++ b/src/main/java/ecplugins/puppet/client/PuppetConfigList.java
@@ -1,0 +1,120 @@
+/**
+ *  Copyright 2015 Electric Cloud, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// PuppetConfigList.java --
+//
+// PuppetConfigList.java is part of ElectricFlow.
+//
+// Copyright (c) 2015 Electric Cloud, Inc.
+// All rights reserved.
+//
+
+package ecplugins.puppet.client;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.xml.client.Document;
+import com.google.gwt.xml.client.Node;
+import com.google.gwt.xml.client.XMLParser;
+
+import static com.electriccloud.commander.gwt.client.util.XmlUtil.getNodeByName;
+import static com.electriccloud.commander.gwt.client.util.XmlUtil.getNodeValueByName;
+import static com.electriccloud.commander.gwt.client.util.XmlUtil.getNodesByName;
+
+public class PuppetConfigList
+{
+
+    //~ Instance fields --------------------------------------------------------
+
+    private final Map<String, PuppetConfigInfo> m_configInfo =
+        new TreeMap<String, PuppetConfigInfo>();
+
+    //~ Methods ----------------------------------------------------------------
+
+    public void addConfig(
+            String configName)
+    {
+        m_configInfo.put(configName, new PuppetConfigInfo());
+    }
+
+    public String parseResponse(String cgiResponse)
+    {
+        Document document     = XMLParser.parse(cgiResponse);
+        Node     responseNode = getNodeByName(document, "response");
+        String   error        = getNodeValueByName(responseNode, "error");
+
+        if (error != null && !error.isEmpty()) {
+            return error;
+        }
+
+        Node       configListNode = getNodeByName(responseNode, "cfgs");
+        List<Node> configNodes    = getNodesByName(configListNode, "cfg");
+
+        for (Node configNode : configNodes) {
+            String configName   = getNodeValueByName(configNode, "name");
+
+            addConfig(configName);
+        }
+
+        return null;
+    }
+
+    public void populateConfigListBox(ListBox lb)
+    {
+
+        for (String configName : m_configInfo.keySet()) {
+            lb.addItem(configName);
+        }
+    }
+
+    public Set<String> getConfigNames()
+    {
+        return m_configInfo.keySet();
+    }
+
+    public String getEditorDefinition(String configName)
+    {
+        return "EC-Puppet";
+    }
+
+    public boolean isEmpty()
+    {
+        return m_configInfo.isEmpty();
+    }
+
+    public void setEditorDefinition(
+            String editorDefiniton)
+    {
+    }
+
+    //~ Inner Classes ----------------------------------------------------------
+
+    private class PuppetConfigInfo
+    {
+
+        //~ Instance fields ----------------------------------------------------
+
+        //~ Constructors -------------------------------------------------------
+
+        public PuppetConfigInfo()
+        {
+        }
+    }
+}

--- a/src/main/java/ecplugins/puppet/client/PuppetConfigListLoader.java
+++ b/src/main/java/ecplugins/puppet/client/PuppetConfigListLoader.java
@@ -1,0 +1,258 @@
+/**
+ *  Copyright 2015 Electric Cloud, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// PuppetConfigListLoader.java --
+//
+// PuppetConfigListLoader.java is part of ElectricFlow.
+//
+// Copyright (c) puppet Electric Cloud, Inc.
+// All rights reserved.
+//
+
+package ecplugins.puppet.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gwt.http.client.Request;
+import com.google.gwt.http.client.RequestCallback;
+import com.google.gwt.http.client.RequestException;
+import com.google.gwt.http.client.Response;
+
+import ecinternal.client.HasErrorPanel;
+import ecinternal.client.Loader;
+
+import com.electriccloud.commander.client.ChainedCallback;
+import com.electriccloud.commander.gwt.client.Component;
+import com.electriccloud.commander.client.domain.Property;
+import com.electriccloud.commander.gwt.client.requests.CgiRequestProxy;
+import com.electriccloud.commander.client.requests.GetPropertyRequest;
+import com.electriccloud.commander.client.responses.CommanderError;
+import com.electriccloud.commander.client.responses.PropertyCallback;
+import com.electriccloud.commander.client.util.StringUtil;
+
+import static ecinternal.client.InternalComponentBaseFactory.getPluginName;
+
+public class PuppetConfigListLoader
+    extends Loader
+{
+
+    //~ Instance fields --------------------------------------------------------
+
+    private final PuppetConfigList   m_configList;
+    private final CgiRequestProxy m_cgiRequestProxy;
+    private String                m_editorName;
+
+    //~ Constructors -----------------------------------------------------------
+
+    public PuppetConfigListLoader(
+    		PuppetConfigList   configList,
+            Component       component,
+            ChainedCallback callback)
+    {
+        this(configList, null, component, callback);
+    }
+
+    public PuppetConfigListLoader(
+    		PuppetConfigList   configList,
+            String          implementedMethod,
+            Component       component,
+            ChainedCallback callback)
+    {
+        super(component, callback);
+        m_configList      = configList;
+        m_cgiRequestProxy = new CgiRequestProxy(getPluginName(), "puppet.cgi");
+    }
+
+    //~ Methods ----------------------------------------------------------------
+
+    @Override public void load()
+    {
+        Map<String, String> cgiParams = new HashMap<String, String>();
+
+        cgiParams.put("cmd", "getCfgList");
+        loadConfigs(cgiParams);
+    }
+
+    private void loadConfigs(Map<String, String> cgiParams)
+    {
+
+        try {
+            String request = m_cgiRequestProxy.issueGetRequest(cgiParams,
+                    new RequestCallback() {
+                        @Override public void onError(
+                                Request   request,
+                                Throwable exception)
+                        {
+                            ((HasErrorPanel) m_component).addErrorMessage(
+                                "Error loading Puppet configuration list: ",
+                                exception);
+                        }
+
+                        @Override public void onResponseReceived(
+                                Request  request,
+                                Response response)
+                        {
+                            String responseString = response.getText();
+
+                            // if HTML returned we never made it to the CGI
+                            Boolean isHtml = (responseString.indexOf(
+                                        "DOCTYPE HTML") != -1);
+                            String  error;
+
+                            if (!isHtml) {
+                                error = m_configList.parseResponse(
+                                        responseString);
+                            }
+                            else {
+                                error = responseString;
+                            }
+
+                            if (m_component.getLog()
+                                           .isDebugEnabled()) {
+                                m_component.getLog()
+                                           .debug(
+                                               "Recieved CGI response: "
+                                               + responseString
+                                               + " isHTML:" + isHtml
+                                               + " error:" + error);
+                            }
+
+                            if (error != null) {
+                                ((HasErrorPanel) m_component).addErrorMessage(
+                                    error);
+                            }
+                            else {
+
+                                if (StringUtil.isEmpty(m_editorName)
+                                        || m_configList.isEmpty()) {
+
+                                    // We're done!
+                                    if (m_callback != null) {
+                                        m_callback.onComplete();
+                                    }
+                                }
+                                else {
+                                    loadEditors();
+                                }
+                            }
+                        }
+                    });
+
+            if (m_component.getLog()
+                           .isDebugEnabled()) {
+                m_component.getLog()
+                           .debug("Issued CGI request: " + request);
+            }
+        }
+        catch (RequestException e) {
+
+            if (m_component instanceof HasErrorPanel) {
+                ((HasErrorPanel) m_component).addErrorMessage(
+                    "Error loading Puppet configuration list: ", e);
+            }
+            else {
+                m_component.getLog()
+                           .error(e);
+            }
+        }
+    }
+
+    private void loadEditors()
+    {
+        GetPropertyRequest request =
+            m_requestFactory.createGetPropertyRequest();
+
+        request.setPropertyName("/plugins/EC-Puppet/project/ui_forms/"
+                + m_editorName);
+        request.setExpand(false);
+        request.setCallback(new EditorLoaderCallback("puppetcfg"));
+        m_requestManager.doRequest(new ChainedCallback() {
+                @Override public void onComplete()
+                {
+
+                    // We're done!
+                    if (m_callback != null) {
+                        m_callback.onComplete();
+                    }
+                }
+            }, request);
+    }
+
+    public void setEditorName(String editorName)
+    {
+        m_editorName = editorName;
+    }
+
+    //~ Inner Classes ----------------------------------------------------------
+
+    public class EditorLoaderCallback
+        implements PropertyCallback
+    {
+
+        //~ Instance fields ----------------------------------------------------
+
+        private final String m_configPlugin;
+
+        //~ Constructors -------------------------------------------------------
+
+        public EditorLoaderCallback(String configPlugin)
+        {
+            m_configPlugin = configPlugin;
+        }
+
+        //~ Methods ------------------------------------------------------------
+
+        @Override public void handleError(CommanderError error)
+        {
+
+            if (m_component instanceof HasErrorPanel) {
+                ((HasErrorPanel) m_component).addErrorMessage(error);
+            }
+            else {
+                m_component.getLog()
+                           .error(error);
+            }
+        }
+
+        @Override public void handleResponse(Property response)
+        {
+
+            if (m_component.getLog()
+                           .isDebugEnabled()) {
+                m_component.getLog()
+                           .debug("Commander getProperty request returned: "
+                               + response);
+            }
+
+            if (response != null) {
+                m_configList.setEditorDefinition(m_configPlugin);
+            }
+
+            // There was no property value found in the response
+            String errorMsg = "Editor '" + m_editorName
+                    + "' not found for Puppet plugin '" + m_configPlugin + "'";
+
+            if (m_component instanceof HasErrorPanel) {
+                ((HasErrorPanel) m_component).addErrorMessage(errorMsg);
+            }
+            else {
+                m_component.getLog()
+                           .error(errorMsg);
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 
      Copyright 2015 Electric Cloud, Inc.
@@ -27,8 +27,9 @@
     <help>EC-Puppet_help.xml</help>
     <commander-version min="4.2"/>
     <components>
-        <component name="configure">
-        	
+        <component name="ConfigurationManagement">
+            <javascript>war/ecplugins.puppet.ConfigurationManagement/ecplugins.puppet.ConfigurationManagement.nocache.js</javascript>
         </component>
     </components>
+    <configure>configurations.xml</configure>
 </plugin>

--- a/src/main/resources/ecplugins/puppet/ConfigurationManagement.gwt.xml
+++ b/src/main/resources/ecplugins/puppet/ConfigurationManagement.gwt.xml
@@ -1,0 +1,30 @@
+<!--
+
+     Copyright 2015 Electric Cloud, Inc.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<module>
+    <entry-point class="ecplugins.puppet.client.ConfigurationManagementFactory"/>
+    <inherits name="com.electriccloud.commander.gwt.ComponentBase"/>
+    <inherits name="ecinternal.ECInternal"/>
+    <!-- The following property limits the plugin to work with Firefox.  This saves tremendously
+    during development because the gwt compiler has to generate less <language,browser> sets of
+    javascript files. Be careful to re-comment this when doing a build of your plugin that you
+    plan to publish!
+    <set-property name="user.agent" value="gecko1_8" />
+    -->
+    <!-- Reduce JAR size by restricting locales to build: remove this if the plugin is localized -->
+    <set-property name="locale" value="default"/>
+</module>

--- a/src/main/resources/project/conf/createcfg.pl
+++ b/src/main/resources/project/conf/createcfg.pl
@@ -1,0 +1,75 @@
+#
+#  Copyright 2015 Electric Cloud, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+#########################
+## createcfg.pl
+#########################
+
+use ElectricCommander;
+use ElectricCommander::PropDB;
+
+use constant {
+    SUCCESS => 0,
+    ERROR   => 1,
+};
+
+my $opts;
+
+my $PLUGIN_NAME = "EC-Puppet";
+
+## get an EC object
+my $ec = new ElectricCommander();
+$ec->abortOnError(0);
+
+## load option list from procedure parameters
+my $x = $ec->getJobDetails( $ENV{COMMANDER_JOBID} );
+my $nodeset = $x->find("//actualParameter");
+foreach my $node ( $nodeset->get_nodelist ) {
+    my $parm = $node->findvalue("actualParameterName");
+    my $val  = $node->findvalue("value");
+    $opts->{$parm} = "$val";
+}
+
+if ( !defined $opts->{config} || "$opts->{config}" eq "" ) {
+    print "config parameter must exist and be non-blank
+";
+    exit ERROR;
+}
+
+# check to see if a config with this name already exists before we do anything else
+my $xpath = $ec->getProperty("/myProject/puppet_cfgs/$opts->{config}");
+my $property = $xpath->findvalue("//response/property/propertyName");
+
+if ( defined $property && "$property" ne "" ) {
+    my $errMsg = "A configuration named '$opts->{config}' already exists.";
+    $ec->setProperty( "/myJob/configError", $errMsg );
+    print $errMsg;
+    exit ERROR;
+}
+
+my $cfg = new ElectricCommander::PropDB( $ec, "/myProject/puppet_cfgs" );
+  
+# add all the options as properties
+foreach my $key ( keys %{$opts} ) {
+    
+    if ( "$key" eq "config" ) {
+        next;
+    }
+	
+    $cfg->setCol( "$opts->{config}", "$key", "$opts->{$key}" );
+}
+
+exit SUCCESS;

--- a/src/main/resources/project/conf/deletecfg.pl
+++ b/src/main/resources/project/conf/deletecfg.pl
@@ -1,0 +1,59 @@
+#
+#  Copyright 2015 Electric Cloud, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+##########################
+# deletecfg.pl
+##########################
+
+use ElectricCommander;
+use ElectricCommander::PropDB;
+
+use constant {
+    SUCCESS => 0,
+    ERROR   => 1,
+};
+
+my $opts;
+
+my $projName = "@PLUGIN_KEY@-@PLUGIN_VERSION@";
+
+## get an EC object
+my $ec = new ElectricCommander();
+$ec->abortOnError(0);
+
+my $opts;
+$opts->{config} = "$[config]";
+
+if ( !defined $opts->{config} || "$opts->{config}" eq "" ) {
+    print "config parameter must exist and be non-blank
+";
+    exit ERROR;
+}
+
+# check to see if a config with this name already exists before we do anything else
+my $xpath = $ec->getProperty("/myProject/puppet_cfgs/$opts->{config}");
+my $property = $xpath->findvalue("//response/property/propertyName");
+
+if ( !defined $property || "$property" eq "" ) {
+    my $errMsg = "Error: A configuration named '$opts->{config}' does not exist.";
+    $ec->setProperty( "/myJob/configError", $errMsg );
+    print $errMsg;
+    exit ERROR;
+}
+
+$ec->deleteProperty("/myProject/puppet_cfgs/$opts->{config}");
+$ec->deleteCredential( $projName, $opts->{config} );
+exit SUCCESS;

--- a/src/main/resources/project/manifest.xml
+++ b/src/main/resources/project/manifest.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' standalone='yes'?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 
      Copyright 2015 Electric Cloud, Inc.
@@ -15,34 +15,49 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 
--->
-<fileset>
+--><fileset>
   <file>
     <path>RunCommand.xml</path>
-    <xpath>//procedure[procedureName=&quot;RunCommand&quot;]/propertySheet/property[propertyName=&quot;ec_parameterForm&quot;]/value</xpath>
+    <xpath>//procedure[procedureName="RunCommand"]/propertySheet/property[propertyName="ec_parameterForm"]/value</xpath>
   </file>
   <file>
     <path>RunManifest.xml</path>
-    <xpath>//procedure[procedureName=&quot;RunManifest&quot;]/propertySheet/property[propertyName=&quot;ec_parameterForm&quot;]/value</xpath>
+    <xpath>//procedure[procedureName="RunManifest"]/propertySheet/property[propertyName="ec_parameterForm"]/value</xpath>
   </file>
   <file>
     <path>RunCommandDriver.pl</path>
-    <xpath>//property[propertyName=&quot;scripts&quot;]/propertySheet/property[propertyName=&quot;RunCommand&quot;]/value</xpath>
+    <xpath>//property[propertyName="scripts"]/propertySheet/property[propertyName="RunCommand"]/value</xpath>
   </file>
   <file>
     <path>RunManifestDriver.pl</path>
-    <xpath>//property[propertyName=&quot;scripts&quot;]/propertySheet/property[propertyName=&quot;RunManifest&quot;]/value</xpath>
+    <xpath>//property[propertyName="scripts"]/propertySheet/property[propertyName="RunManifest"]/value</xpath>
   </file>
   <file>
     <path>PuppetHelper.pm</path>
-    <xpath>//property[propertyName=&quot;libs&quot;]/propertySheet/property[propertyName=&quot;PuppetHelper.pm&quot;]/value</xpath>
+    <xpath>//property[propertyName="libs"]/propertySheet/property[propertyName="PuppetHelper.pm"]/value</xpath>
   </file>
   <file>
     <path>ec_setup.pl</path>
-    <xpath>//property[propertyName=&quot;ec_setup&quot;]/value</xpath>
+    <xpath>//property[propertyName="ec_setup"]/value</xpath>
   </file>
   <file>
     <path>postp_matchers.pl</path>
-    <xpath>//property[propertyName=&quot;postp_matchers&quot;]/value</xpath>
+    <xpath>//property[propertyName="postp_matchers"]/value</xpath>
+  </file>
+<file>
+    <path>ui_forms/CreateConfigForm.xml</path>
+    <xpath>//property[propertyName='ui_forms']/propertySheet/property[propertyName='CreateConfigForm']/value</xpath>
+  </file>
+  <file>
+    <path>ui_forms/EditConfigForm.xml</path>
+    <xpath>//property[propertyName='ui_forms']/propertySheet/property[propertyName='EditConfigForm']/value</xpath>
+  </file>
+  <file>
+    <path>conf/createcfg.pl</path>
+    <xpath>//procedure[procedureName='CreateConfiguration']/step[stepName='CreateConfiguration']/command</xpath>
+  </file>
+  <file>
+    <path>conf/deletecfg.pl</path>
+    <xpath>//procedure[procedureName='DeleteConfiguration']/step[stepName='DeleteConfiguration']/command</xpath>
   </file>
 </fileset>

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -1,26 +1,26 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<exportedData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="commander.xsd" version="42" buildLabel="build_3.7_34336_OPT_2010.07.26_15:26:49" buildVersion="3.7.0.34336">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<exportedData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" buildLabel="build_3.7_34336_OPT_2010.07.26_15:26:49" buildVersion="3.7.0.34336" version="42" xsi:noNamespaceSchemaLocation="commander.xsd">
     <exportPath>/projects/@PLUGIN_KEY@-@PLUGIN_VERSION@</exportPath>
     <project>
         <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
         <description>Integration with Puppet</description>
-        <workspaceName></workspaceName>
+        <workspaceName/>
         <propertySheet>
             <property>
                 <propertyName>scripts</propertyName>
-                <description></description>
+                <description/>
                 <propertySheet>
                     <property>
                         <propertyName>RunManifest</propertyName>
                         <description>Runs a manifest file on Puppet.</description>
                         <expandable>1</expandable>
-                        <value></value>
+                        <value/>
                     </property>
                     <property>
                         <propertyName>RunCommand</propertyName>
                         <description>Runs a command on Puppet.</description>
                         <expandable>1</expandable>
-                        <value></value>
+                        <value/>
                     </property>
                 </propertySheet>
             </property>
@@ -32,9 +32,9 @@
                 <propertySheet>
                     <property>
                         <propertyName>PuppetHelper.pm</propertyName>
-                        <description></description>
+                        <description/>
                         <expandable>1</expandable>
-                        <value></value>
+                        <value/>
                     </property>
                 </propertySheet>
             </property>
@@ -52,19 +52,155 @@
             </property>
             <property>
                 <propertyName>postp_matchers</propertyName>
-                <value></value>
+                <value/>
                 <expandable>0</expandable>
             </property>
             <property>
                 <propertyName>ec_setup</propertyName>
                 <expandable>0</expandable>
-                <value></value>
+                <value/>
             </property>
             <property>
                 <propertyName>ec_visibility</propertyName>
-                <description></description>
+                <description/>
                 <expandable>1</expandable>
                 <value>pickListOnly</value>
+            </property>
+            <property>
+                <propertyName>ui_forms</propertyName>
+                <description>Property sheet to hold XML specification for forms</description>
+                <propertySheet>
+                    <property>
+                        <propertyName>CreateConfigForm</propertyName>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                    <property>
+                        <propertyName>EditConfigForm</propertyName>
+                        <description/>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                </propertySheet>
+            </property>
+            <property>
+                <propertyName>ui_forms</propertyName>
+                <description>Property sheet to hold XML specification for forms</description>
+                <propertySheet>
+                    <property>
+                        <propertyName>CreateConfigForm</propertyName>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                    <property>
+                        <propertyName>EditConfigForm</propertyName>
+                        <description/>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                </propertySheet>
+            </property>
+            <property>
+                <propertyName>ui_forms</propertyName>
+                <description>Property sheet to hold XML specification for forms</description>
+                <propertySheet>
+                    <property>
+                        <propertyName>CreateConfigForm</propertyName>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                    <property>
+                        <propertyName>EditConfigForm</propertyName>
+                        <description/>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                </propertySheet>
+            </property>
+            <property>
+                <propertyName>ui_forms</propertyName>
+                <description>Property sheet to hold XML specification for forms</description>
+                <propertySheet>
+                    <property>
+                        <propertyName>CreateConfigForm</propertyName>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                    <property>
+                        <propertyName>EditConfigForm</propertyName>
+                        <description/>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                </propertySheet>
+            </property>
+            <property>
+                <propertyName>ui_forms</propertyName>
+                <description>Property sheet to hold XML specification for forms</description>
+                <propertySheet>
+                    <property>
+                        <propertyName>CreateConfigForm</propertyName>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                    <property>
+                        <propertyName>EditConfigForm</propertyName>
+                        <description/>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                </propertySheet>
+            </property>
+            <property>
+                <propertyName>ui_forms</propertyName>
+                <description>Property sheet to hold XML specification for forms</description>
+                <propertySheet>
+                    <property>
+                        <propertyName>CreateConfigForm</propertyName>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                    <property>
+                        <propertyName>EditConfigForm</propertyName>
+                        <description/>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                </propertySheet>
+            </property>
+            <property>
+                <propertyName>ui_forms</propertyName>
+                <description>Property sheet to hold XML specification for forms</description>
+                <propertySheet>
+                    <property>
+                        <propertyName>CreateConfigForm</propertyName>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                    <property>
+                        <propertyName>EditConfigForm</propertyName>
+                        <description/>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                </propertySheet>
+            </property>
+            <property>
+                <propertyName>ui_forms</propertyName>
+                <description>Property sheet to hold XML specification for forms</description>
+                <propertySheet>
+                    <property>
+                        <propertyName>CreateConfigForm</propertyName>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                    <property>
+                        <propertyName>EditConfigForm</propertyName>
+                        <description/>
+                        <expandable>1</expandable>
+                        <value/>
+                    </property>
+                </propertySheet>
             </property>
         </propertySheet>
         <procedure>
@@ -247,9 +383,9 @@
                 </property>
                 <property>
                     <propertyName>ec_parameterForm</propertyName>
-                    <description></description>
+                    <description/>
                     <expandable>0</expandable>
-                    <value></value>
+                    <value/>
                 </property>
             </propertySheet>
             <formalParameter>
@@ -261,7 +397,7 @@
             </formalParameter>
             <formalParameter>
                 <formalParameterName>manifest_type</formalParameterName>
-                <defaultValue></defaultValue>
+                <defaultValue/>
                 <description>Choose the manifest type to use, available opcions are: File, TextArea. (Required)</description>
                 <required>1</required>
                 <type>select</type>
@@ -275,21 +411,21 @@
             </formalParameter>
             <formalParameter>
                 <formalParameterName>debug</formalParameterName>
-                <defaultValue></defaultValue>
+                <defaultValue/>
                 <description>If checked full debugging will be enabled.</description>
                 <required>0</required>
                 <type>checkbox</type>
             </formalParameter>
             <formalParameter>
                 <formalParameterName>verbose_mode</formalParameterName>
-                <defaultValue></defaultValue>
+                <defaultValue/>
                 <description>If checked the verbose mode is activated.</description>
                 <required>0</required>
                 <type>checkbox</type>
             </formalParameter>
             <formalParameter>
                 <formalParameterName>noop</formalParameterName>
-                <defaultValue></defaultValue>
+                <defaultValue/>
                 <description>If checked simulate run by applying a manifest.</description>
                 <required>0</required>
                 <type>checkbox</type>
@@ -377,9 +513,9 @@
                 </property>
                 <property>
                     <propertyName>ec_parameterForm</propertyName>
-                    <description></description>
+                    <description/>
                     <expandable>0</expandable>
-                    <value></value>
+                    <value/>
                 </property>
             </propertySheet>
             <formalParameter>
@@ -417,6 +553,1416 @@
                 <workingDirectory/>
                 <workspaceName/>
                 <procedureName>RunCommand</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>CreateConfiguration</procedureName>
+            <description>Create a Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <property>
+                                    <propertyName>desc</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <property>
+                                    <propertyName>master_server_url</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <!-- Insert your form properties definitions here -->
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>Configuration Name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <formalParameter>
+                <formalParameterName>desc</formalParameterName>
+                <defaultValue/>
+                <description>Simple description for configuration</description>
+                <type>entry</type>
+            </formalParameter>
+            <formalParameter>
+                <formalParameterName>master_server_url</formalParameterName>
+                <defaultValue/>
+                <description>URL for Puppet's master server</description>
+                <type>entry</type>
+            </formalParameter>
+            <!-- Insert your formal parameters definitions here -->
+            <step>
+                <stepName>CreateConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Create a Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>CreateConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>DeleteConfiguration</procedureName>
+            <description>Delete an Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>The configuration name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <step>
+                <stepName>DeleteConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Delete an Puppet configuration
+                </description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>DeleteConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>CreateConfiguration</procedureName>
+            <description>Create a Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <property>
+                                    <propertyName>desc</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <!-- Insert your form properties definitions here -->
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>Configuration Name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <formalParameter>
+                <formalParameterName>desc</formalParameterName>
+                <defaultValue/>
+                <description>Simple description for configuration</description>
+                <type>entry</type>
+            </formalParameter>
+            <!-- Insert your formal parameters definitions here -->
+            <step>
+                <stepName>CreateConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Create a Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>CreateConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>DeleteConfiguration</procedureName>
+            <description>Delete an Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>The configuration name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <step>
+                <stepName>DeleteConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Delete an Puppet configuration
+                </description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>DeleteConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>CreateConfiguration</procedureName>
+            <description>Create a Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <property>
+                                    <propertyName>desc</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <!-- Insert your form properties definitions here -->
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>Configuration Name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <formalParameter>
+                <formalParameterName>desc</formalParameterName>
+                <defaultValue/>
+                <description>Simple description for configuration</description>
+                <type>entry</type>
+            </formalParameter>
+            <!-- Insert your formal parameters definitions here -->
+            <step>
+                <stepName>CreateConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Create a Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>CreateConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>DeleteConfiguration</procedureName>
+            <description>Delete an Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>The configuration name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <step>
+                <stepName>DeleteConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Delete an Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>DeleteConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>CreateConfiguration</procedureName>
+            <description>Create a Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <property>
+                                    <propertyName>desc</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <!-- Insert your form properties definitions here -->
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>Configuration Name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <formalParameter>
+                <formalParameterName>desc</formalParameterName>
+                <defaultValue/>
+                <description>Simple description for configuration</description>
+                <type>entry</type>
+            </formalParameter>
+            <!-- Insert your formal parameters definitions here -->
+            <step>
+                <stepName>CreateConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Create a Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>CreateConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>DeleteConfiguration</procedureName>
+            <description>Delete an Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>The configuration name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <step>
+                <stepName>DeleteConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Delete an Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>DeleteConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>CreateConfiguration</procedureName>
+            <description>Create a Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <property>
+                                    <propertyName>desc</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <!-- Insert your form properties definitions here -->
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>Configuration Name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <formalParameter>
+                <formalParameterName>desc</formalParameterName>
+                <defaultValue/>
+                <description>Simple description for configuration</description>
+                <type>entry</type>
+            </formalParameter>
+            <!-- Insert your formal parameters definitions here -->
+            <step>
+                <stepName>CreateConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Create a Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>CreateConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>DeleteConfiguration</procedureName>
+            <description>Delete an Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>The configuration name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <step>
+                <stepName>DeleteConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Delete an Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>DeleteConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>CreateConfiguration</procedureName>
+            <description>Create a Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <property>
+                                    <propertyName>desc</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <!-- Insert your form properties definitions here -->
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>Configuration Name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <formalParameter>
+                <formalParameterName>desc</formalParameterName>
+                <defaultValue/>
+                <description>Simple description for configuration</description>
+                <type>entry</type>
+            </formalParameter>
+            <!-- Insert your formal parameters definitions here -->
+            <step>
+                <stepName>CreateConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Create a Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>CreateConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>DeleteConfiguration</procedureName>
+            <description>Delete an Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>The configuration name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <step>
+                <stepName>DeleteConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Delete an Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>DeleteConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>CreateConfiguration</procedureName>
+            <description>Create a Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <property>
+                                    <propertyName>desc</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <!-- Insert your form properties definitions here -->
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>Configuration Name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <formalParameter>
+                <formalParameterName>desc</formalParameterName>
+                <defaultValue/>
+                <description>Simple description for configuration</description>
+                <type>entry</type>
+            </formalParameter>
+            <!-- Insert your formal parameters definitions here -->
+            <step>
+                <stepName>CreateConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Create a Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>CreateConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>DeleteConfiguration</procedureName>
+            <description>Delete an Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>The configuration name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <step>
+                <stepName>DeleteConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Delete an Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>DeleteConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>CreateConfiguration</procedureName>
+            <description>Create a Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <property>
+                                    <propertyName>desc</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                                <!-- Insert your form properties definitions here -->
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>Configuration Name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <formalParameter>
+                <formalParameterName>desc</formalParameterName>
+                <defaultValue/>
+                <description>Simple description for configuration</description>
+                <type>entry</type>
+            </formalParameter>
+            <!-- Insert your formal parameters definitions here -->
+            <step>
+                <stepName>CreateConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Create a Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>CreateConfiguration</procedureName>
+                <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+                <propertySheet>
+                    <property>
+                        <propertyName>ec_customEditorData</propertyName>
+                        <propertySheet>
+                            <property>
+                                <propertyName>formType</propertyName>
+                                <expandable>1</expandable>
+                                <value>command</value>
+                            </property>
+                        </propertySheet>
+                    </property>
+                </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>DeleteConfiguration</procedureName>
+            <description>Delete an Puppet configuration</description>
+            <jobNameTemplate>puppet-cfg-$[jobId]</jobNameTemplate>
+            <resourceName/>
+            <workspaceName/>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_visibility</propertyName>
+                    <description/>
+                    <expandable>1</expandable>
+                    <value>hidden</value>
+                </property>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>config</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>config</formalParameterName>
+                <defaultValue/>
+                <description>The configuration name</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <step>
+                <stepName>DeleteConfiguration</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <command/>
+                <condition/>
+                <description>Delete an Puppet configuration</description>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <logFileName/>
+                <parallel>0</parallel>
+                <postProcessor>postp</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName>local</resourceName>
+                <retries>0</retries>
+                <shell>ec-perl</shell>
+                <timeLimit>5</timeLimit>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <workingDirectory/>
+                <workspaceName/>
+                <procedureName>DeleteConfiguration</procedureName>
                 <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
                 <propertySheet>
                     <property>

--- a/src/main/resources/project/ui_forms/CreateConfigForm.xml
+++ b/src/main/resources/project/ui_forms/CreateConfigForm.xml
@@ -1,0 +1,35 @@
+<!--
+
+     Copyright 2015 Electric Cloud, Inc.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<editor>
+    <formElement>
+        <type>entry</type>
+        <label>Configuration Name:</label>
+        <property>config</property>
+        <value></value>
+        <required>1</required>
+        <documentation>Provide a unique name for the configuration, keeping in mind that you may need to create additional configurations over time.</documentation>
+    </formElement>
+    <formElement>
+        <type>entry</type>
+        <label>Description:</label>
+        <property>desc</property>
+        <value>Puppet configuration</value>
+        <documentation>Provide a simple description for this configuration.</documentation>
+    </formElement>
+    <!-- Insert your fields definitions here -->
+</editor>

--- a/src/main/resources/project/ui_forms/EditConfigForm.xml
+++ b/src/main/resources/project/ui_forms/EditConfigForm.xml
@@ -1,0 +1,26 @@
+<!--
+
+     Copyright 2015 Electric Cloud, Inc.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<editor>
+    <formElement>
+        <type>entry</type>
+        <label>Description:</label>
+        <property>desc</property>
+        <documentation>Provide a simple description for this configuration.</documentation>
+    </formElement>
+    <!-- Insert your fields definitions here -->
+</editor>


### PR DESCRIPTION
Added initial configuration management to EC-Puppet plugin
Bumped version of plugin to 1.0.4

Note for developers:

To add necessary properties to plugin';s configuration,
one will need to modify following files:

src/main/resources/project/project.xml
src/main/resources/project/ui_forms/CreateConfigForm.xml
src/main/resources/project/ui_forms/EditConfigForm.xml

Places, where to insert new properties marked with 'Insert your ... here'.

To add new fields in plugin's configuration list,
one will need to modify following files:

src/main/java/ecplugins/puppet/client/ConfigurationList.java
src/main/java/ecplugins/puppet/client/PuppetConfigList.java
src/main/java/ecplugins/puppet/client/PuppetConfigListLoader.java