### PR TITLE
ConfigureAgent procedure skeleton that calls RunAgent proc for processing

### DIFF
--- a/src/main/resources/project/ec_setup.pl
+++ b/src/main/resources/project/ec_setup.pl
@@ -14,6 +14,13 @@
 #  limitations under the License.
 #
 
+my %ConfigureAgent = (
+    label       => "Puppet- Configure Agent",
+    procedure   => "ConfigureAgent",
+    description => "Used by the dynamic environment feature to configure the Puppet agent on the provisioned resource. Retrieves the client configuration from the Puppet Master and applies it to the resource based on the environment specified.",
+    category    => "Resource Management"
+);
+
 my %RunManifest = (
     label       => "Puppet - Run Manifest",
     procedure   => "RunManifest",
@@ -126,11 +133,15 @@ $batch->deleteProperty(
     "/server/ec_customEditors/pickerStep/EC-Puppet - RunAgent");
 $batch->deleteProperty("/server/ec_customEditors/pickerStep/Puppet - RunAgent");
 
+$batch->deleteProperty(
+    "/server/ec_customEditors/pickerStep/EC-Puppet - ConfigureAgent");
+$batch->deleteProperty("/server/ec_customEditors/pickerStep/Puppet - ConfigureAgent");
+
 @::createStepPickerSteps = (
     \%RunManifest,                   \%RunCommand,
     \%ManageCertificatesAndRequests, \%PuppetParser,
     \%PuppetModules,                 \%PuppetLint,
     \%PuppetUnitTest,                \%PuppetVersion,
-    \%RunAgent
+    \%RunAgent,                      \%ConfigureAgent,
 );
 

--- a/src/main/resources/project/manifest.xml
+++ b/src/main/resources/project/manifest.xml
@@ -33,6 +33,10 @@
         <xpath>//procedure[procedureName="PuppetParser"]/propertySheet/property[propertyName="ec_parameterForm"]/value</xpath>
     </file>
     <file>
+        <path>procedures/ConfigureAgent/form.xml</path>
+        <xpath>//procedure[procedureName="ConfigureAgent"]/propertySheet/property[propertyName="ec_parameterForm"]/value</xpath>
+    </file>
+    <file>
         <path>procedures/RunAgent/form.xml</path>
         <xpath>//procedure[procedureName="RunAgent"]/propertySheet/property[propertyName="ec_parameterForm"]/value</xpath>
     </file>

--- a/src/main/resources/project/procedures/ConfigureAgent/form.xml
+++ b/src/main/resources/project/procedures/ConfigureAgent/form.xml
@@ -1,0 +1,29 @@
+<!--
+
+     Copyright 2015 Electric Cloud, Inc.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<editor>
+    <help>/commander/pages/@PLUGIN_NAME@/@PLUGIN_KEY@_help?s=Administration&amp;ss=Plugins#ConfigureAgent</help>
+    <formElement>
+        <type>entry</type>
+        <label>Puppet Path:</label>
+        <value>/usr/local/bin/puppet</value>
+        <property>puppet_path</property>
+        <required>1</required>
+        <documentation>Provide the path to the puppet executable e.g /usr/local/bin/puppet. (Required) </documentation>
+    </formElement>
+</editor>
+

--- a/src/main/resources/project/project.xml
+++ b/src/main/resources/project/project.xml
@@ -22,7 +22,7 @@
                                         <propertyName>procedureName</propertyName>
                                         <description></description>
                                         <expandable>1</expandable>
-                                        <value>RunAgent</value>
+                                        <value>ConfigureAgent</value>
                                     </property>
                                     <property>
                                         <propertyName>ui_formRefs</propertyName>
@@ -1973,6 +1973,158 @@
                         </propertySheet>
                     </property>
                 </propertySheet>
+            </step>
+        </procedure>
+        <procedure>
+            <procedureName>ConfigureAgent</procedureName>
+            <description>Used by the dynamic environment feature to configure the Puppet agent on the provisioned resource. Retrieves the client configuration from the Puppet Master and applies it to the resource based on the environment specified.</description>
+            <projectName>@PLUGIN_KEY@-@PLUGIN_VERSION@</projectName>
+            <propertySheet>
+                <property>
+                    <propertyName>ec_customEditorData</propertyName>
+                    <propertySheet>
+                        <property>
+                            <propertyName>parameters</propertyName>
+                            <propertySheet>
+                                <property>
+                                    <propertyName>puppet_path</propertyName>
+                                    <propertySheet>
+                                        <property>
+                                            <propertyName>formType</propertyName>
+                                            <expandable>1</expandable>
+                                            <value>standard</value>
+                                        </property>
+                                    </propertySheet>
+                                </property>
+                            </propertySheet>
+                        </property>
+                    </propertySheet>
+                </property>
+                <property>
+                    <propertyName>ec_parameterForm</propertyName>
+                    <description/>
+                    <expandable>0</expandable>
+                    <value/>
+                </property>
+            </propertySheet>
+            <formalParameter>
+                <formalParameterName>puppet_path</formalParameterName>
+                <defaultValue>/usr/local/bin/puppet</defaultValue>
+                <description>Provide the path to the puppet executable e.g /usr/local/bin/puppet. (Required)</description>
+                <required>1</required>
+                <type>entry</type>
+            </formalParameter>
+            <step>
+                <stepName>configureAgent</stepName>
+                <alwaysRun>0</alwaysRun>
+                <broadcast>0</broadcast>
+                <condition/>
+                <description/>
+                <errorHandling>failProcedure</errorHandling>
+                <exclusive>0</exclusive>
+                <parallel>0</parallel>
+                <postProcessor>postp --loadProperty /myProject/postp_matchers</postProcessor>
+                <releaseExclusive>0</releaseExclusive>
+                <resourceName/>
+                <retries>0</retries>
+                <timeLimit/>
+                <timeLimitUnits>minutes</timeLimitUnits>
+                <subprocedure>RunAgent</subprocedure>
+                <subproject>/plugins/EC-Puppet/project</subproject>
+                <actualParameters>
+                    <!--Pass the values for the RunAgent procedure being invoked here-->
+                    <property>
+                        <propertyName>puppet_path</propertyName>
+                        <expandable>1</expandable>
+                        <!--This is the parameter from the ConfigureAgent procedure-->
+                        <value>$[puppet_path]</value>
+                    </property>
+                    <property>
+                        <propertyName>waitforcert</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>verbose</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>test</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>onetime</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>noop</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>no_daemonize</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>no_client</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>masterport</propertyName>
+                        <expandable>1</expandable>
+                        <value></value>
+                    </property>
+                    <property>
+                        <propertyName>logdest</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>fingerprint</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>enable</propertyName>
+                        <expandable>1</expandable>
+                        <value>1</value>
+                    </property>
+                    <property>
+                        <propertyName>disable</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>digest</propertyName>
+                        <expandable>1</expandable>
+                        <value></value>
+                    </property>
+                    <property>
+                        <propertyName>detailed_exitcodes</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>debug</propertyName>
+                        <expandable>1</expandable>
+                        <value>0</value>
+                    </property>
+                    <property>
+                        <propertyName>certname</propertyName>
+                        <expandable>1</expandable>
+                        <value></value>
+                    </property>
+                    <property>
+                        <propertyName>additional_options</propertyName>
+                        <expandable>1</expandable>
+                        <value></value>
+                    </property>
+                </actualParameters>
             </step>
         </procedure>
         <procedure>


### PR DESCRIPTION
o ConfigureAgent configured as the converge procedure for dynamic envt.
o ConfigureAgent is a skeleton proc that needs to be built fully to
support configuring a newly provisioned VM.
- Contains just one formal parameter puppet_path to demonstrate passing
its value to the sub procedure 'RunAgent' in its step.
- Other parameters in 'RunAgent' set with default values as an example.
They should be reviewed and updated as required.