### PR TITLE
removed configure link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /target
 /export
 /staging
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 
 group = "com.electriccloud"
 description = "Plugins : EC-Puppet"
-version = "1.1.1"
+version = "1.1.2"
 
 apply plugin: 'flow-gradle-plugin'
 apply plugin: 'license'

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,5 +31,4 @@
             <javascript>war/ecplugins.puppet.ConfigurationManagement/ecplugins.puppet.ConfigurationManagement.nocache.js</javascript>
         </component>
     </components>
-    <configure>configurations.xml</configure>
 </plugin>


### PR DESCRIPTION
Since puppet plugin doesn't use configurations at all, link has been removed. All puppet procedures accepts all required data through regular procedure config.